### PR TITLE
Implement focus trapping for modals and menu

### DIFF
--- a/scripts-optimized.min.js
+++ b/scripts-optimized.min.js
@@ -16,11 +16,13 @@
     };
 
     // Estado global de la aplicación
-    const state = {
+const state = {
         isMenuOpen: false,
         hasScrolled: false,
         formSubmitting: false,
-        activeModalId: null
+        activeModalId: null,
+        prevFocusedElement: null,
+        focusTrapHandler: null
     };
 
     // DATOS DE TODOS LOS PROYECTOS DEL PORTAFOLIO
@@ -256,8 +258,9 @@
 
     // Funcionalidades del Header
     const header = { /* ... (código sin cambios, asegurando que closeMobileMenu esté definido) ... */
-        init: function() { const headerEl = document.querySelector('.header-optimized'); const menuToggleBtn = document.getElementById('mobile-menu'); const navMenuEl = document.querySelector('.nav-menu'); if (!headerEl) return; window.addEventListener('scroll', utils.throttle(() => { headerEl.classList.toggle('scrolled', window.scrollY > config.scrollThreshold); }, 100), { passive: true }); if (menuToggleBtn && navMenuEl) { menuToggleBtn.addEventListener('click', () => { state.isMenuOpen = !state.isMenuOpen; menuToggleBtn.classList.toggle('is-active', state.isMenuOpen); navMenuEl.classList.toggle('is-active', state.isMenuOpen); menuToggleBtn.setAttribute('aria-expanded', state.isMenuOpen.toString()); document.body.classList.toggle('no-scroll', state.isMenuOpen); }); navMenuEl.addEventListener('click', (e) => { if (e.target.matches('a') && state.isMenuOpen) { this.closeMobileMenu(menuToggleBtn, navMenuEl); } }); document.addEventListener('click', (e) => { if (state.isMenuOpen && !navMenuEl.contains(e.target) && !menuToggleBtn.contains(e.target)) { this.closeMobileMenu(menuToggleBtn, navMenuEl); } }); } },
-        closeMobileMenu: function(toggleBtn, menuEl) { state.isMenuOpen = false; toggleBtn.classList.remove('is-active'); menuEl.classList.remove('is-active'); toggleBtn.setAttribute('aria-expanded', 'false'); document.body.classList.remove('no-scroll'); }
+        init: function() { const headerEl = document.querySelector('.header-optimized'); const menuToggleBtn = document.getElementById('mobile-menu'); const navMenuEl = document.querySelector('.nav-menu'); if (!headerEl) return; window.addEventListener('scroll', utils.throttle(() => { headerEl.classList.toggle('scrolled', window.scrollY > config.scrollThreshold); }, 100), { passive: true }); if (menuToggleBtn && navMenuEl) { menuToggleBtn.addEventListener('click', () => { if(state.isMenuOpen){ this.closeMobileMenu(menuToggleBtn, navMenuEl); } else { this.openMobileMenu(menuToggleBtn, navMenuEl); } }); navMenuEl.addEventListener('click', (e) => { if (e.target.matches('a') && state.isMenuOpen) { this.closeMobileMenu(menuToggleBtn, navMenuEl); } }); document.addEventListener('click', (e) => { if (state.isMenuOpen && !navMenuEl.contains(e.target) && !menuToggleBtn.contains(e.target)) { this.closeMobileMenu(menuToggleBtn, navMenuEl); } }); } },
+        openMobileMenu: function(toggleBtn, menuEl) { state.prevFocusedElement = document.activeElement; state.isMenuOpen = true; toggleBtn.classList.add('is-active'); menuEl.classList.add('is-active'); toggleBtn.setAttribute('aria-expanded', 'true'); document.body.classList.add('no-scroll'); const firstFocusable = menuEl.querySelector('a, button, [tabindex]:not([tabindex="-1"])'); if(firstFocusable) firstFocusable.focus(); state.focusTrapHandler = e => { if(e.key === 'Tab'){ const focusable = menuEl.querySelectorAll('a, button, [tabindex]:not([tabindex="-1"])'); if(focusable.length===0) return; const first = focusable[0]; const last = focusable[focusable.length-1]; if(e.shiftKey){ if(document.activeElement === first){ e.preventDefault(); last.focus(); } } else { if(document.activeElement === last){ e.preventDefault(); first.focus(); } } } else if(e.key === 'Escape'){ header.closeMobileMenu(toggleBtn, menuEl); } }; menuEl.addEventListener('keydown', state.focusTrapHandler); },
+        closeMobileMenu: function(toggleBtn, menuEl) { state.isMenuOpen = false; toggleBtn.classList.remove('is-active'); menuEl.classList.remove('is-active'); toggleBtn.setAttribute('aria-expanded', 'false'); document.body.classList.remove('no-scroll'); if(state.focusTrapHandler) menuEl.removeEventListener('keydown', state.focusTrapHandler); state.focusTrapHandler = null; if(state.prevFocusedElement) { state.prevFocusedElement.focus(); state.prevFocusedElement = null; } }
     };
 
     // Notification Bar
@@ -314,6 +317,7 @@
         openModal: function(modalId) {
             const modal = document.getElementById(modalId);
             if (modal) {
+                state.prevFocusedElement = document.activeElement;
                 modal.style.display = 'flex';
                 document.body.classList.add('no-scroll-modal-open'); // Evita scroll del body
                 state.activeModalId = modalId;
@@ -328,7 +332,22 @@
 
                 const firstFocusable = modal.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
                 if (firstFocusable) firstFocusable.focus();
-                modal.addEventListener("keydown",e=>{if(e.key==="Escape") modals.closeModal(modal);})
+                state.focusTrapHandler = e => {
+                    if(e.key === 'Tab'){
+                        const focusable = modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+                        if(focusable.length===0) return;
+                        const first = focusable[0];
+                        const last = focusable[focusable.length-1];
+                        if(e.shiftKey){
+                            if(document.activeElement === first){ e.preventDefault(); last.focus(); }
+                        } else {
+                            if(document.activeElement === last){ e.preventDefault(); first.focus(); }
+                        }
+                    } else if(e.key === 'Escape'){
+                        modals.closeModal(modal);
+                    }
+                };
+                modal.addEventListener('keydown', state.focusTrapHandler);
                 analytics.trackEvent('UI Interaction', 'Modal Opened', modalId);
             }
         },
@@ -343,6 +362,10 @@
                     modalContent.style.overflowY = ''; // Restablecer
                     modalContent.style.maxHeight = ''; // Restablecer
                 }
+
+                if(state.focusTrapHandler) modalElement.removeEventListener('keydown', state.focusTrapHandler);
+                state.focusTrapHandler = null;
+                if(state.prevFocusedElement) { state.prevFocusedElement.focus(); state.prevFocusedElement = null; }
 
                 if (state.activeModalId === modalElement.id) state.activeModalId = null;
                 analytics.trackEvent('UI Interaction', 'Modal Closed', modalElement.id);


### PR DESCRIPTION
## Summary
- maintain previously focused element in global state
- trap focus in mobile menu and restore on close
- trap focus within modals and restore on close

## Testing
- `node -c scripts-optimized.min.js`

------
https://chatgpt.com/codex/tasks/task_e_68499178e590832aaa8ec3429bd11846