### PR TITLE
Defer hero video loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@
 
     <!-- Optimized CSS -->
     <link rel="stylesheet" href="style-optimized.min.css">
-    <link rel="preload" href="videos/hero-background.mp4" as="video" type="video/mp4">
     
     <!-- Schema Markup -->
     <script type="application/ld+json">
@@ -94,8 +93,8 @@
 <main id="main-content">
 
     <section id="hero" class="hero-optimized">
-        <video autoplay loop muted playsinline id="hero-video" poster="images/fondo1.jpg" loading="lazy"> 
-            <source src="videos/hero-background.mp4" type="video/mp4">
+        <video autoplay loop muted playsinline id="hero-video" poster="images/fondo1.jpg" loading="lazy">
+            <source src="" data-src="videos/hero-background.mp4" type="video/mp4">
             Tu navegador no soporta el tag de video. Te recomendamos actualizarlo para una mejor experiencia.
         </video>
         <div class="hero-overlay"></div>

--- a/scripts-optimized.min.js
+++ b/scripts-optimized.min.js
@@ -282,7 +282,29 @@
 
     // Hero Section
     const hero = { /* ... (código sin cambios) ... */
-        init: function() { const video = document.getElementById('hero-video'); if (video && typeof IntersectionObserver !== 'undefined') { const videoObserver = new IntersectionObserver((entries) => { entries.forEach(entry => { if (entry.isIntersecting) { if (video.paused) video.play().catch(e => console.warn("Video play:", e)); } else { if (!video.paused) video.pause(); } }); }, { threshold: 0.2 }); videoObserver.observe(video); } }
+        init: function() {
+            const video = document.getElementById('hero-video');
+            if (!video) return;
+            window.addEventListener('load', () => {
+                const source = video.querySelector('source');
+                if (source && source.dataset.src && !source.src) {
+                    source.src = source.dataset.src;
+                    video.load();
+                }
+                if (typeof IntersectionObserver !== 'undefined') {
+                    const videoObserver = new IntersectionObserver((entries) => {
+                        entries.forEach(entry => {
+                            if (entry.isIntersecting) {
+                                if (video.paused) video.play().catch(e => console.warn("Video play:", e));
+                            } else {
+                                if (!video.paused) video.pause();
+                            }
+                        });
+                    }, { threshold: 0.2 });
+                    videoObserver.observe(video);
+                }
+            });
+        }
     };
 
     // Smooth Scroll para enlaces de ancla


### PR DESCRIPTION
## Summary
- remove `hero-background.mp4` preload
- keep hero video source empty until runtime
- load hero video after window load before creating IntersectionObserver

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68499174ccc4832a8e12ade42f7ffcfb